### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -1,6 +1,7 @@
 var express = require("express"),
   multer = require("multer"),
   fs = require("fs"),
+  path = require("path"),
   router = express.Router();
 router.get("/", function (req, res, next) {
   res.render("/public/index.html", { title: "files" });
@@ -13,15 +14,18 @@ var upload = multer({
   },
 });
 router.post("/upload/", upload.any(), function (req, res) {
-  var path = req.files[0].path;
-  var pathNew = path + "_" + req.files[0].originalname;
+  var uploadRoot = "../html/uploads/";
+  var tempPath = req.files[0].path;
+  var tempName = path.basename(tempPath);
+  var safeOriginalName = path.basename(req.files[0].originalname || "");
+  var safeNewPath = path.join(uploadRoot, tempName + "_" + safeOriginalName);
 
-  fs.rename(path, pathNew, function (err) {
+  fs.rename(tempPath, safeNewPath, function (err) {
     if (err) throw err;
   });
 
   res.type("json");
-  const link = pathNew.replace("../html/", "");
+  const link = safeNewPath.replace("../html/", "");
   res.json({ link, type: req.files[0].mimetype });
   res.end();
 });


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/fg/security/code-scanning/1](https://github.com/192kb/fg/security/code-scanning/1)

In general, to fix uncontrolled path usage for file uploads, compute all filesystem paths from a fixed, trusted base directory and only use sanitized file names (not user-supplied paths). Avoid passing user data directly as part of any path to `fs` methods. Normalize constructed paths and ensure they remain under the intended root directory.

For this specific code, we should:
- Define a trusted upload root (e.g. `../html/uploads/`).
- Ignore any directory components in `req.files[0].originalname` by taking only its basename.
- Generate the final filename under the upload root, using the Multer-generated temporary filename (or its basename) plus the sanitized original name suffix.
- Use `path.join` and `path.basename` from Node’s `path` module to avoid manual string concatenation for paths.
- Optionally, ensure the final resolved path stays within the upload root (for defense in depth).

Within `routes/index.js`, we can:
1. Add `path = require("path")` to the existing `var` declarations at the top.
2. Replace the block where `path` and `pathNew` are computed and used:
   - Avoid shadowing the `path` module with a `var path`.
   - Introduce `uploadRoot` from the known Multer destination.
   - Use `path.basename(req.files[0].path)` to get the temporary name, and `path.basename(req.files[0].originalname)` to avoid directories.
   - Build `safeNewPath` via `path.join(uploadRoot, tempName + "_" + safeOriginalName)`.
   - Call `fs.rename(req.files[0].path, safeNewPath, ...)`.
   - Compute `link` from `safeNewPath` by replacing the `../html/` prefix as before.

This preserves functionality (same directory, same naming pattern) while ensuring that the destination path cannot escape the intended upload directory via user-controlled input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
