### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ejs": "^4.0.1",
     "express": "^5.2.1",
     "multer": "^2.0.2",
-    "serve-favicon": "^2.5.1"
+    "serve-favicon": "^2.5.1",
+    "express-rate-limit": "^8.2.1"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,6 +3,14 @@ var express = require("express"),
   fs = require("fs"),
   path = require("path"),
   router = express.Router();
+
+var RateLimit = require("express-rate-limit");
+
+var uploadLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 upload requests per windowMs
+});
+
 router.get("/", function (req, res, next) {
   res.render("/public/index.html", { title: "files" });
 });
@@ -13,7 +21,7 @@ var upload = multer({
     fileSize: 1 * 1024 * 1024 * 1024,
   },
 });
-router.post("/upload/", upload.any(), function (req, res) {
+router.post("/upload/", uploadLimiter, upload.any(), function (req, res) {
   var uploadRoot = "../html/uploads/";
   var tempPath = req.files[0].path;
   var tempName = path.basename(tempPath);

--- a/routes/index.js
+++ b/routes/index.js
@@ -29,12 +29,19 @@ router.post("/upload/", uploadLimiter, upload.any(), function (req, res) {
   var safeNewPath = path.join(uploadRoot, tempName + "_" + safeOriginalName);
 
   fs.rename(tempPath, safeNewPath, function (err) {
-    if (err) throw err;
-  });
+    if (err) {
+      console.error("Error moving uploaded file from %s to %s: %s", tempPath, safeNewPath, err && err.message ? err.message : err);
+      if (!res.headersSent) {
+        res.status(500);
+        res.end();
+      }
+      return;
+    }
 
-  res.type("json");
-  const link = safeNewPath.replace("../html/", "");
-  res.json({ link, type: req.files[0].mimetype });
-  res.end();
+    res.type("json");
+    const link = safeNewPath.replace("../html/", "");
+    res.json({ link, type: req.files[0].mimetype });
+    res.end();
+  });
 });
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/fg/security/code-scanning/6](https://github.com/192kb/fg/security/code-scanning/6)

To fix the issue, add a rate-limiting middleware to the `/upload/` route so that uploads are only accepted at a controlled rate. The ideal fix is to use a well-known library such as `express-rate-limit`, configure a limiter specifically for the upload route (so we don’t change behavior of unrelated routes), and apply it before `multer` in the middleware chain to reject abusive traffic early.

Concretely, in `routes/index.js`, we will: (1) add a `require("express-rate-limit")` statement; (2) define a limiter configuration (e.g., a reasonable number of upload requests per IP per time window); and (3) update the `router.post("/upload/", ...)` definition to insert the limiter middleware before `upload.any()`. This preserves all existing upload behavior for compliant users while adding protection against high-rate abuse. No other logic (file naming, JSON response, etc.) needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
