### PR TITLE
Potential fix for code scanning alert no. 9: Uncontrolled data used in path expression

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -24,13 +24,25 @@ var upload = multer({
 router.post("/upload/", uploadLimiter, upload.any(), function (req, res) {
   var uploadRoot = "../html/uploads/";
   var tempPath = req.files[0].path;
-  var tempName = path.basename(tempPath);
+  var resolvedUploadRoot = path.resolve(uploadRoot);
+  var resolvedTempPath = path.resolve(tempPath);
+
+  // Ensure that the temporary upload path is actually within the intended upload root
+  if (resolvedTempPath !== resolvedUploadRoot && !resolvedTempPath.startsWith(resolvedUploadRoot + path.sep)) {
+    console.error("Rejected file move from unexpected temp path: %s", tempPath);
+    if (!res.headersSent) {
+      res.status(400).end();
+    }
+    return;
+  }
+
+  var tempName = path.basename(resolvedTempPath);
   var safeOriginalName = path.basename(req.files[0].originalname || "");
   var safeNewPath = path.join(uploadRoot, tempName + "_" + safeOriginalName);
 
-  fs.rename(tempPath, safeNewPath, function (err) {
+  fs.rename(resolvedTempPath, safeNewPath, function (err) {
     if (err) {
-      console.error("Error moving uploaded file from %s to %s: %s", tempPath, safeNewPath, err && err.message ? err.message : err);
+      console.error("Error moving uploaded file from %s to %s: %s", resolvedTempPath, safeNewPath, err && err.message ? err.message : err);
       if (!res.headersSent) {
         res.status(500);
         res.end();

--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,10 @@ var express = require("express"),
   path = require("path"),
   router = express.Router();
 
+// Define a single, absolute upload root and resolve any symlinks.
+var uploadRoot = path.resolve(__dirname, "../html/uploads/");
+var resolvedUploadRoot = fs.realpathSync(uploadRoot);
+
 var RateLimit = require("express-rate-limit");
 
 var uploadLimiter = RateLimit({
@@ -15,17 +19,17 @@ router.get("/", function (req, res, next) {
   res.render("/public/index.html", { title: "files" });
 });
 var upload = multer({
-  dest: "../html/uploads/",
+  // Use the resolved upload root as the Multer destination
+  dest: resolvedUploadRoot,
   limits: {
     files: 250,
     fileSize: 1 * 1024 * 1024 * 1024,
   },
 });
 router.post("/upload/", uploadLimiter, upload.any(), function (req, res) {
-  var uploadRoot = "../html/uploads/";
   var tempPath = req.files[0].path;
-  var resolvedUploadRoot = path.resolve(uploadRoot);
-  var resolvedTempPath = path.resolve(tempPath);
+  // Resolve the temporary path to an absolute, symlink-free path
+  var resolvedTempPath = fs.realpathSync(path.resolve(tempPath));
 
   // Ensure that the temporary upload path is actually within the intended upload root
   if (resolvedTempPath !== resolvedUploadRoot && !resolvedTempPath.startsWith(resolvedUploadRoot + path.sep)) {
@@ -38,7 +42,7 @@ router.post("/upload/", uploadLimiter, upload.any(), function (req, res) {
 
   var tempName = path.basename(resolvedTempPath);
   var safeOriginalName = path.basename(req.files[0].originalname || "");
-  var safeNewPath = path.join(uploadRoot, tempName + "_" + safeOriginalName);
+  var safeNewPath = path.join(resolvedUploadRoot, tempName + "_" + safeOriginalName);
 
   fs.rename(resolvedTempPath, safeNewPath, function (err) {
     if (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/fg/security/code-scanning/9](https://github.com/192kb/fg/security/code-scanning/9)

In general, to fix uncontrolled-path issues you must ensure that any path derived from user-controllable data is either: (a) validated to be within an expected root directory after normalization, or (b) reduced to a simple filename with no path components using `path.basename` or a sanitization library, and then joined with a trusted root.

Here, the safest minimal change is to assert that `tempPath` (the Multer-generated temporary file location) actually resides under the expected upload root before using it in `fs.rename`. We already have `uploadRoot = "../html/uploads/"`. We can:

1. Resolve both `uploadRoot` and `tempPath` to absolute, normalized paths using `path.resolve`.
2. Check that the resolved `tempPath` starts with the resolved upload root path plus a path separator (or equals it).
3. If the check fails, respond with HTTP 400 or 403 and do not call `fs.rename`.
4. Use the resolved `tempPath` (not the original tainted one) in `fs.rename`.

This keeps the existing behavior (moving the file within the same upload directory and returning the same link) but adds a clear, explicit guard. All necessary utilities (`path`, `fs`) are already imported at the top of `routes/index.js`, so no new imports are required. The changes are confined to the POST `/upload/` handler around lines 24–45: add resolution and validation of `tempPath` and use the validated variable in the `fs.rename` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
